### PR TITLE
made the qemu verification a little less strict

### DIFF
--- a/oemid/verify-qemu.yml
+++ b/oemid/verify-qemu.yml
@@ -8,8 +8,8 @@
     - assert:
         that: 
           - ansible_processor_vcpus == 2
-          - ansible_product_version == 'pc-i440fx-2.9'
-          - ansible_memtotal_mb == 992
+            #- ansible_product_version == 'pc-i440fx-2.9'
+          - ansible_memtotal_mb >= 992
           - ansible_architecture == 'x86_64'
           - ansible_system_vendor == 'QEMU'
           - ansible_distribution == 'RedHat'


### PR DESCRIPTION
I removed the check for the product_version since this is HV dependant and brings no benefit imho and changed the memory requirement from being exactly 992MB to be at least 992MB.