### PR TITLE
Display the volume type while doing the installation

### DIFF
--- a/gluster-colonizer.py
+++ b/gluster-colonizer.py
@@ -758,6 +758,8 @@ try:
                 oem_id['flavor']['node']['name'] + "\033[0m")
     logger.info("Your deployment flavor is \t\033[31m" +
                 oem_id['flavor']['name'] + "\033[0m")
+    logger.info("Your deployment volume type is \t\033[31m" +
+                oem_id['flavor']['voltype'] + "\033[0m")
 
     try:
         if str(oem_id['flavor']['voltype']) == "replica":


### PR DESCRIPTION
I thought that listing which volume type the flavour is using may be good during install.