### PR TITLE
Better cleanup of LVM metadata

### DIFF
--- a/ansible/g1-deploy.yml
+++ b/ansible/g1-deploy.yml
@@ -168,7 +168,7 @@
     # there. This is the only way to be sure there's no old lvm metadata 
     # anymore which would cause duplicate PVs etc. 
     - name: Clean up residual LVM metadata from all cache partition offsets
-      shell: /bin/bash -c "/usr/bin/dd if=/dev/zero of={{ item[0] }} bs=512 obs=512 count=8192 seek={{ ( 512|int * (arbiter_end|default(50)|int + ((item[1]['id']|int * cache_part_size|int))) + 1|int) }} oflag=seek_bytes,sync"
+      shell: /bin/bash -c "/usr/bin/dd if=/dev/zero of={{ item[0] }} bs=1M count=4 seek={{ ( 512|int * (arbiter_end|default(50)|int + ((item[1]['id']|int * cache_part_size|int))) + 1|int) }} oflag=seek_bytes,direct"
       with_nested:
         - "{{ cache_devices }}"
         - "{{ backend_configuration }}"


### PR DESCRIPTION
1. Do not use small blocks. 1M writes should be far more efficient.
2. Use directIO - no need to cache this and direct IO does not need sync.

Note: wasn't tested. I don't have a system to test on (need to set up a virtual env. perhaps!)